### PR TITLE
added: cache/call.ts full radis implementaion.

### DIFF
--- a/apps/nova/src/pages/Call.tsx
+++ b/apps/nova/src/pages/Call.tsx
@@ -18,6 +18,7 @@ import { useAppSelector } from "@/redux/store";
 import { profileSelectors } from "@/redux/user/profile";
 import { orNull, orUndefined } from "@litespace/sol/utils";
 import {
+  useCallMembers,
   // useCall,
   useCallV2,
   useFindCallRoomById,
@@ -50,6 +51,12 @@ const Call: React.FC = () => {
   }, [id]);
 
   const callRoom = useFindCallRoomById(!isGhost ? callId : null);
+
+
+  const members = useCallMembers(callId, "interview");
+  useEffect(() => {
+    console.log("In View: members = ", members);
+  }, [members])
 
   const mateInfo = useMemo(() => {
     if (!callRoom.data) return;

--- a/packages/atlas/src/call.ts
+++ b/packages/atlas/src/call.ts
@@ -9,4 +9,8 @@ export class Call extends Base {
   async findById(id: number): Promise<ICall.FindCallByIdApiResponse> {
     return await this.get(`/api/v1/call/${id}`);
   }
+
+  async findCallMembers(id: number): Promise<ICall.FindCallMembersByCallIdApiResponse> {
+    return await this.get(`/api/v1/call/${id}/members`);
+  }
 }

--- a/packages/models/src/cache/base.ts
+++ b/packages/models/src/cache/base.ts
@@ -13,8 +13,18 @@ export type RedisClient = RedisClientType<
 
 export class CacheBase {
   constructor(
-    public client: RedisClientType<RedisModules, RedisFunctions, RedisScripts>
+    public client: RedisClient
   ) {}
+
+  // return class to define and store redis value
+  RValue(prefix: string) {
+    return new RValue(this.client, prefix);
+  }
+
+  // return class to define and store redis set
+  RSet(prefix: string) {
+    return new RSet(this.client, prefix);
+  }
 
   encode<T extends object | string | number>(values: T): string {
     return JSON.stringify(values);
@@ -22,5 +32,103 @@ export class CacheBase {
 
   decode<T>(values: string): T {
     return JSON.parse(values) as T;
+  }
+}
+
+/*
+ *  ancillary class that's used in Cache to represent redis key-set pairs
+ */
+class RSet {
+  private prefix: string;
+  private _client: RedisClient;
+
+  constructor(client: RedisClient, prefix: string) {
+    this.prefix = prefix;
+    this._client = client;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  async get(key: string) {
+    const list = await this.client.sMembers(`${this.prefix}:${key}`);
+    return list.map(v => this.decode(v));
+  }
+  
+  add(key: string, value: string) {
+    this.client.sAdd(`${this.prefix}:${key}`, this.encode(value));
+    return this;
+  }
+
+  rmv(key: string, value: string) {
+    this.client.sRem(`${this.prefix}:${key}`, this.encode(value))
+    return this;
+  }
+
+  expire(key: string, seconds: number) {
+    this.client.expire(`${this.prefix}:${key}`, seconds);
+    return this;
+  }
+
+  encode<T extends object | string | number>(values: T): string {
+    return JSON.stringify(values);
+  }
+
+  decode<T>(values: string): T {
+    return JSON.parse(values) as T;
+  }
+
+  prefixKey(key: string): string {
+    return `${this.prefix}:${key}`
+  }
+}
+
+/*
+ *  ancillary class that's used in Cache to represent redis key-value pairs
+ */
+class RValue {
+  private prefix: string;
+  private _client: RedisClient;
+
+  constructor(client: RedisClient, prefix: string) {
+    this.prefix = prefix;
+    this._client = client;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  async get(key: string) {
+    const value = await this.client.get(`${this.prefix}:${key}`);
+    return value ? this.decode(value) : null;
+  }
+  
+  set(key: string, value: string) {
+    this.client.set(`${this.prefix}:${key}`, this.encode(value));
+    return this;
+  }
+
+  del(key: string) {
+    this.client.del(`${this.prefix}:${key}`)
+    return this;
+  }
+
+  expire(key: string, seconds: number) {
+    this.client.expire(`${this.prefix}:${key}`, seconds);
+    return this;
+  }
+
+  encode<T extends object | string | number>(values: T): string {
+    return JSON.stringify(values);
+  }
+
+  decode<T>(values: string): T {
+    return JSON.parse(values) as T;
+  }
+
+  prefixKey(key: string): string {
+    return `${this.prefix}:${key}`
   }
 }

--- a/packages/models/src/cache/call.ts
+++ b/packages/models/src/cache/call.ts
@@ -2,8 +2,10 @@ import { CacheBase } from "@/cache/base";
 
 export class Call extends CacheBase {
   private readonly prefixes = {
-    call: "call",
-    user: "user:call",
+    callJoined: "call:joined:members", // prefix for each call id that maps to a set of its joined members ids. string -> set
+    callCanJoin: "call:canjoin:users", // prefix for each call id that maps to a set of eligible (can join) members ids. string -> set
+    userCalls: "user:calls", // prefix for each user id that maps to a set of all calls that he can join
+    userJoinedCall: "user:joined:call", // prefix for each user id that maps to the last joined call id. string -> string
   };
   private ttl = 60 * 60; // 1 hour
 
@@ -12,39 +14,61 @@ export class Call extends CacheBase {
     return this;
   }
 
-  async addMember({ callId, userId }: { callId: number; userId: number }) {
-    const callKey = this.asCallKey(callId);
-    const userKey = this.asUserKey(userId);
+  // Join member to call
+  async joinMember({ callId, userId }: { callId: number; userId: number }) {
+    const callKey = this.asCallKey(callId).joined;
+    const userKey = this.asUserKey(userId).joinedCall;
     await this.client
       .multi()
       .sAdd(callKey, this.encode(userId))
-      .set(userKey, this.encode(callId))
       .expire(callKey, this.ttl)
+      .set(userKey, this.encode(callId))
       .expire(userKey, this.ttl)
       .exec();
   }
 
-  async removeMember({ callId, userId }: { callId: number; userId: number }) {
+  // leave member from call
+  async leaveMember({ callId, userId }: { callId: number; userId: number }) {
+    const callKey = this.asCallKey(callId).joined;
+    const userKey = this.asUserKey(userId).joinedCall;
     await this.client
       .multi()
-      .sRem(this.asCallKey(callId), userId.toString())
-      .del(this.asUserKey(userId))
+      .sRem(callKey, userId.toString())
+      .del(userKey)
+      .exec();
+  }
+  async leaveMemberByUserId(userId: number) {
+    const result = await this.client.get(this.asUserKey(userId).joinedCall);
+    if (!result) return;
+    const callId = this.decode(result) as number;
+    await this.leaveMember({ callId, userId });
+  }
+  
+  // make user an eligible member to join a call
+  async addMember({ callId, userId }: { callId: number; userId: number }) {
+    const callKey = this.asCallKey(callId).canJoin;
+    const userKey = this.asUserKey(userId).calls;
+    await this.client
+      .multi()
+      .sAdd(callKey, this.encode(userId))
+      .expire(callKey, this.ttl)
+      .sAdd(userKey, this.encode(callId))
       .exec();
   }
 
-  async removeMemberByUserId(userId: number) {
-    const result = await this.client.get(this.asUserKey(userId));
-    if (!result) return;
-    const callId = this.decode(result) as number;
-    await this.removeMember({ callId, userId });
+  // make user an uneligible member; cannot join the call
+  async rmvMember({ callId, userId }: { callId: number; userId: number }) {
+    const callKey = this.asCallKey(callId).canJoin;
+    const userKey = this.asUserKey(userId).calls;
+    await this.client
+      .multi()
+      .sRem(callKey, userId.toString())
+      .sRem(userKey, callId.toString())
+      .exec();
   }
 
-  async getMembers(callId: number): Promise<number[]> {
-    const result = await this.client.sMembers(this.asCallKey(callId));
-    return result.map((value) => this.decode(value));
-  }
-
-  async isMember({
+  // returns true if the user joined to the call
+  async isJoinedMember({
     callId,
     userId,
   }: {
@@ -52,16 +76,50 @@ export class Call extends CacheBase {
     userId: number;
   }): Promise<boolean> {
     return await this.client.sIsMember(
-      this.asCallKey(callId),
+      this.asCallKey(callId).joined,
       this.encode(userId)
     );
   }
 
-  private asCallKey(callId: number): string {
-    return `${this.prefixes.call}:${callId}`;
+  // returns true if the user belongs to the call
+  async isEligibleMember({
+    callId,
+    userId,
+  }: {
+    callId: number;
+    userId: number;
+  }): Promise<boolean> {
+    return await this.client.sIsMember(
+      this.asCallKey(callId).canJoin,
+      this.encode(userId)
+    );
   }
 
-  private asUserKey(userId: number): string {
-    return `${this.prefixes.user}:${userId}`;
+  // returns list of calls ids to which a specifc user belongs
+  async getCallsOfUser(userId: number): Promise<number[]> {
+    const ids = await this.client.sMembers(
+      this.asUserKey(userId).calls
+    );
+    return ids ? ids.map((id) => Number(id)) : []
+  }
+
+  // returns the call id that a user has joined
+  async getJoinedCallByUser(userId: number): Promise<number | null> {
+    const id = await this.client.get(this.asUserKey(userId).joinedCall);
+    return id ? Number(id) : null;
+  }
+
+  private asCallKey(callId: number) {
+    return {
+      joined: `${this.prefixes.callJoined}:${callId}`,
+      canJoin: `${this.prefixes.callCanJoin}:${callId}`,
+    }
+  }
+
+  private asUserKey(userId: number){
+    return {
+      joinedCall: `${this.prefixes.userJoinedCall}:${userId}`,
+      calls: `${this.prefixes.userCalls}:${userId}`,
+    };
   }
 }

--- a/packages/models/src/cache/call.ts
+++ b/packages/models/src/cache/call.ts
@@ -1,70 +1,55 @@
-import { CacheBase } from "@/cache/base";
+import { CacheBase, RedisClient } from "@/cache/base";
 
 export class Call extends CacheBase {
-  private readonly prefixes = {
-    callJoined: "call:joined:members", // prefix for each call id that maps to a set of its joined members ids. string -> set
-    callCanJoin: "call:canjoin:users", // prefix for each call id that maps to a set of eligible (can join) members ids. string -> set
-    userCalls: "user:calls", // prefix for each user id that maps to a set of all calls that he can join
-    userJoinedCall: "user:joined:call", // prefix for each user id that maps to the last joined call id. string -> string
-  };
-  private ttl = 60 * 60; // 1 hour
+  private callInMembers; // callId -> userId[]
+  private callAllMembers; // callId -> userId[]
+  private userCalls; // userId -> callId[]
+  private userJoinedCall; // userId -> callId
 
-  withTtl(ttl: number): Call {
-    this.ttl = ttl;
-    return this;
+  constructor(client: RedisClient) {
+    super(client)
+    this.callInMembers = this.RSet("call:in:members")
+    this.callAllMembers = this.RSet("call:all:members")
+    this.userCalls = this.RSet("user:calls")
+    this.userJoinedCall = this.RValue("user:joined:call")
   }
 
   // Join member to call
   async joinMember({ callId, userId }: { callId: number; userId: number }) {
-    const callKey = this.asCallKey(callId).joined;
-    const userKey = this.asUserKey(userId).joinedCall;
-    await this.client
-      .multi()
-      .sAdd(callKey, this.encode(userId))
-      .expire(callKey, this.ttl)
-      .set(userKey, this.encode(callId))
-      .expire(userKey, this.ttl)
-      .exec();
+    const CALL = callId.toString();
+    const USER = userId.toString();
+    this.callInMembers.add(CALL, USER).expire(CALL, 60 * 60);
+    this.userJoinedCall.set(USER, CALL);
   }
 
   // leave member from call
   async leaveMember({ callId, userId }: { callId: number; userId: number }) {
-    const callKey = this.asCallKey(callId).joined;
-    const userKey = this.asUserKey(userId).joinedCall;
-    await this.client
-      .multi()
-      .sRem(callKey, userId.toString())
-      .del(userKey)
-      .exec();
+    const CALL = callId.toString();
+    const USER = userId.toString();
+    this.callInMembers.rmv(CALL, USER);
+    this.userJoinedCall.del(USER);
   }
+
   async leaveMemberByUserId(userId: number) {
-    const result = await this.client.get(this.asUserKey(userId).joinedCall);
-    if (!result) return;
-    const callId = this.decode(result) as number;
-    await this.leaveMember({ callId, userId });
+    const callId = await this.userJoinedCall.get(userId.toString());
+    if (typeof callId !== "string") return;
+    await this.leaveMember({ callId: Number(callId), userId });
   }
   
   // make user an eligible member to join a call
   async addMember({ callId, userId }: { callId: number; userId: number }) {
-    const callKey = this.asCallKey(callId).canJoin;
-    const userKey = this.asUserKey(userId).calls;
-    await this.client
-      .multi()
-      .sAdd(callKey, this.encode(userId))
-      .expire(callKey, this.ttl)
-      .sAdd(userKey, this.encode(callId))
-      .exec();
+    const CALL = callId.toString();
+    const USER = userId.toString();
+    this.userCalls.add(USER, CALL);
+    this.callAllMembers.add(CALL, USER);
   }
 
-  // make user an uneligible member; cannot join the call
+  // make user uneligible member; cannot join the call
   async rmvMember({ callId, userId }: { callId: number; userId: number }) {
-    const callKey = this.asCallKey(callId).canJoin;
-    const userKey = this.asUserKey(userId).calls;
-    await this.client
-      .multi()
-      .sRem(callKey, userId.toString())
-      .sRem(userKey, callId.toString())
-      .exec();
+    const CALL = callId.toString();
+    const USER = userId.toString();
+    this.callInMembers.rmv(CALL, USER);
+    this.userCalls.rmv(USER, CALL);
   }
 
   // returns true if the user joined to the call
@@ -75,9 +60,11 @@ export class Call extends CacheBase {
     callId: number;
     userId: number;
   }): Promise<boolean> {
-    return await this.client.sIsMember(
-      this.asCallKey(callId).joined,
-      this.encode(userId)
+    const CALL = callId.toString();
+    const USER = userId.toString();
+    return await this.callInMembers.client.sIsMember(
+      this.callInMembers.prefixKey(CALL),
+      this.callInMembers.encode(USER)
     );
   }
 
@@ -89,37 +76,23 @@ export class Call extends CacheBase {
     callId: number;
     userId: number;
   }): Promise<boolean> {
-    return await this.client.sIsMember(
-      this.asCallKey(callId).canJoin,
-      this.encode(userId)
+    const CALL = callId.toString();
+    const USER = userId.toString();
+    return await this.callAllMembers.client.sIsMember(
+      this.callAllMembers.prefixKey(CALL),
+      this.callAllMembers.encode(USER)
     );
   }
 
   // returns list of calls ids to which a specifc user belongs
   async getCallsOfUser(userId: number): Promise<number[]> {
-    const ids = await this.client.sMembers(
-      this.asUserKey(userId).calls
-    );
+    const ids = await this.userCalls.get(userId.toString());
     return ids ? ids.map((id) => Number(id)) : []
   }
 
   // returns the call id that a user has joined
   async getJoinedCallByUser(userId: number): Promise<number | null> {
-    const id = await this.client.get(this.asUserKey(userId).joinedCall);
+    const id = await this.userJoinedCall.get(userId.toString());
     return id ? Number(id) : null;
-  }
-
-  private asCallKey(callId: number) {
-    return {
-      joined: `${this.prefixes.callJoined}:${callId}`,
-      canJoin: `${this.prefixes.callCanJoin}:${callId}`,
-    }
-  }
-
-  private asUserKey(userId: number){
-    return {
-      joinedCall: `${this.prefixes.userJoinedCall}:${userId}`,
-      calls: `${this.prefixes.userCalls}:${userId}`,
-    };
   }
 }

--- a/packages/models/src/cache/index.ts
+++ b/packages/models/src/cache/index.ts
@@ -14,6 +14,7 @@ export class Cache {
 
   constructor(url: string) {
     const client = createClient({ url });
+    client.on('error', (err) => console.log('Redis Client Error', err));
     this.client = client;
     this.tutors = new Tutors(client);
     this.rules = new Rules(client);
@@ -27,5 +28,9 @@ export class Cache {
 
   async connect() {
     await this.client.connect();
+  }
+
+  async disconnect() {
+    await this.client.quit();
   }
 }

--- a/packages/types/src/call.ts
+++ b/packages/types/src/call.ts
@@ -74,4 +74,9 @@ export type FindUserCallsApiResponse = {
   members: Record<string, PopuldatedMember[]>;
 };
 
+export type FindCallMembersByCallIdApiResponse = {
+  members: PopuldatedMember[];
+};
+
+
 export type Type = "lesson" | "interview";

--- a/services/server/fixtures/db.ts
+++ b/services/server/fixtures/db.ts
@@ -28,6 +28,7 @@ import { Time } from "@litespace/sol/time";
 export { faker } from "@faker-js/faker/locale/ar";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { controllers } from "@/controllers";
 
 dayjs.extend(utc);
 
@@ -114,7 +115,7 @@ const or = {
     return id;
   },
   async callId(id?: number): Promise<number> {
-    if (!id) return await calls.create().then((call) => call.id);
+    if (!id) return await controllers.calls.create().then(call => call.id);
     return id;
   },
   async ruleId(id?: number): Promise<number> {

--- a/services/server/src/controllers/calls.ts
+++ b/services/server/src/controllers/calls.ts
@@ -1,0 +1,111 @@
+import { redisUrl } from "@/constants";
+import ResponseError, { notfound } from "@/lib/error";
+import { Cache, calls } from "@litespace/models";
+import { ICall } from "@litespace/types";
+
+type KCallId = string;
+
+type Memo = {
+  calls: {[k: KCallId]: ICall.Self};
+  callsJoinedMembers: {[k: KCallId]: ICall.PopuldatedMember[]}
+}
+
+/* 
+ * This controller ensures harmony and synchronously between posgtesql and redis.
+ * components should communicate with the db with **ONLY** this component.
+ */
+export class CallsController {
+  // TODO: consider adding memo to avoid dispatching redundant queries to the database
+  // NOTE: remeber to modify/reset the memo on each data manipulation
+  private _redis: Cache | null;
+
+  constructor() {
+    this._redis = null;
+  }
+
+  // this getter is a connect-disconnect shorthand wrapper to simplify code
+  private get redis(): Cache {
+    if (this._redis !== null) return this._redis;
+    this._redis = new Cache(redisUrl);
+    this._redis.connect()
+
+    // auto gracefully disconnect after 10 seconds
+    setTimeout(async () => {
+      if (!this._redis) return
+      await this._redis.disconnect()
+      this._redis = null
+    }, 10 * 1000);
+
+    return this._redis;
+  }
+
+  /*
+   * inserts a call row in the database
+   */
+  async create(): Promise<ICall.Self> {
+    return await calls.create();
+  }
+
+  /*
+   * inserts a call row in the database along with members
+   */
+  async createWithMembers(membersIds: number[]): Promise<ICall.Self> {
+    const call = await calls.create();
+    for (const id of membersIds) {
+      await this.redis.call.addMember({ callId: call.id, userId: id });
+    }
+    return call;
+  }
+
+  async joinMemberToCall({callId, userId}: {callId: number, userId: number}): Promise<void> {
+    // NOTE addMember in knex calls wrapper means joining the call
+    await calls.addMember({ callId, userId });
+    await this.redis.call.joinMember({ callId, userId });
+  }
+
+  async leaveMemberFromCall({callId, userId}: {callId: number, userId: number}): Promise<void> {
+    // NOTE removeMemeber in knex calls wrapper means leaving the call
+    await calls.removeMember({ callId, userId });
+    await this.redis.call.leaveMember({ callId, userId });
+  }
+
+  async leaveMemberFromAll(userId: number): Promise<void> {
+    const callId = Number(await this.redis.call.getJoinedCallByUser(userId));
+    this.leaveMemberFromCall({ userId, callId })
+  }
+
+  /*
+   *  retrieve a specific call object from the database
+   */
+  async getCallById(callId: number): Promise<ICall.Self> {
+    const call = await calls.findById(callId);
+    if (!call) throw notfound.call();
+    return call;
+  }
+
+  /*
+   *  retrieve the list of calls that one user belongs to
+   */
+  async getCallsOfUser(userId: number): Promise<number[]> {
+    return await this.redis.call.getCallsOfUser(userId);
+  }
+
+  /*
+   *  retrieve the list of joined members of a specific call
+   */
+  async getJoinedMembers(callId: number): Promise<ICall.PopuldatedMember[]> {
+    const call = await this.getCallById(callId);
+    if (call instanceof ResponseError) throw call;
+    // NOTE: findCallMembers means retrieve joined members
+    return await calls.findCallMembers([callId]);
+  }
+
+  /*
+   *  check if a user is an eligible member of a call
+   */
+  async isMember({callId, userId}: {callId: number, userId: number}): Promise<boolean> {
+    const call = await this.getCallById(callId);
+    if (call instanceof ResponseError) throw call;
+    return await this.redis.call.isEligibleMember({ userId, callId })
+  }
+}

--- a/services/server/src/controllers/index.ts
+++ b/services/server/src/controllers/index.ts
@@ -1,0 +1,5 @@
+import { CallsController } from "@/controllers/calls"
+
+export const controllers = {
+  calls: new CallsController()
+}

--- a/services/server/src/handlers/call.ts
+++ b/services/server/src/handlers/call.ts
@@ -1,30 +1,66 @@
-import { calls } from "@litespace/models";
 import { NextFunction, Request, Response } from "express";
 import asyncHandler from "express-async-handler";
 import { withNamedId } from "@/validation/utils";
-import { forbidden, notfound } from "@/lib/error";
+import { forbidden } from "@/lib/error";
 import { isAdmin, isGhost, isUser } from "@litespace/auth";
+import { controllers } from "@/controllers";
 
+/*
+  * express handler for retrieving a call object by its id
+  */
 async function findCallById(req: Request, res: Response, next: NextFunction) {
-  const user = req.user;
-  const allowed = isUser(user) || isGhost(user);
-  if (!allowed) return next(forbidden());
+  try {
+    // parse request params/body/queries
+    const { callId } = withNamedId("callId").parse(req.params);
 
-  const { callId } = withNamedId("callId").parse(req.params);
-  const [call, members] = await Promise.all([
-    calls.findById(callId),
-    calls.findCallMembers([callId]),
-  ]);
-  if (!call) return next(notfound.call());
+    // authorize the request
+    const user = req.user;
+    const allowed = isUser(user) || isGhost(user);
+    if (!allowed) throw forbidden();
 
-  const member =
-    isUser(user) && members.map((member) => member.userId).includes(user.id);
-  const eligible = member || isAdmin(req.user) || isGhost(user);
-  if (!eligible) next(forbidden());
+    const isMember = isUser(user) && await controllers.calls.isMember({ userId: user.id, callId });
+    const eligible = isMember || isAdmin(req.user) || isGhost(user);
+    if (!eligible) throw forbidden();
 
-  res.status(200).json({ call, members });
+    // retrieve data from the database
+    const call = await controllers.calls.getCallById(callId)
+    const members = await controllers.calls.getJoinedMembers(callId);
+
+    // send response to the client
+    res.status(200).json({ call, members });
+  } catch(e) {
+    next(e);
+  }
+}
+
+/*
+  * express handler for retrieving a list of members of a specific call
+  */
+async function findCallMembers(req: Request, res: Response, next: NextFunction) {
+  try {
+    // parse request params/body/queries
+    const { callId } = withNamedId("callId").parse(req.params);
+
+    // authorize the request
+    const user = req.user;
+    const allowed = isUser(user) || isGhost(user);
+    if (!allowed) throw forbidden();
+
+    const isMember = isUser(user) && await controllers.calls.isMember({ userId: user.id, callId });
+    const eligible = isMember || isAdmin(req.user) || isGhost(user);
+    if (!eligible) throw forbidden();
+
+    // retrieve data from the database
+    const members = await controllers.calls.getJoinedMembers(callId);
+
+    // send response to the client
+    res.status(200).json({ members });
+  } catch(e) {
+    next(e);
+  }
 }
 
 export default {
   findCallById: asyncHandler(findCallById),
+  findCallMembers: asyncHandler(findCallMembers)
 };

--- a/services/server/src/handlers/interview.ts
+++ b/services/server/src/handlers/interview.ts
@@ -35,6 +35,7 @@ import { isAdmin, isInterviewer, isSuperAdmin, isTutor } from "@litespace/auth";
 import { isEmpty, isEqual } from "lodash";
 import { canBook } from "@/lib/call";
 import { platformConfig } from "@/constants";
+import { controllers } from "@/controllers";
 
 const INTERVIEW_DURATION = 30;
 
@@ -106,7 +107,8 @@ async function createInterview(
   if (!room) await rooms.create(members);
 
   const interview = await knex.transaction(async (tx) => {
-    const call = await calls.create(tx);
+    const call = await controllers.calls
+      .createWithMembers([interviewerId, intervieweeId])
 
     const interview = await interviews.create({
       interviewer: interviewerId,

--- a/services/server/src/handlers/lesson.ts
+++ b/services/server/src/handlers/lesson.ts
@@ -24,6 +24,8 @@ import { cache } from "@/lib/cache";
 import dayjs from "@/lib/dayjs";
 import { canBook } from "@/lib/call";
 import { concat, isEqual } from "lodash";
+import { CallsController } from "@/controllers/calls";
+import { controllers } from "@/controllers";
 
 const createLessonPayload = zod.object({
   tutorId: id,
@@ -85,7 +87,8 @@ function create(context: ApiContext) {
 
       const { lesson } = await knex.transaction(
         async (tx: Knex.Transaction) => {
-          const call = await calls.create(tx);
+          const call = await controllers.calls
+            .createWithMembers([payload.tutorId, user.id])
           const lesson = await lessons.create({
             tutor: payload.tutorId,
             student: user.id,

--- a/services/server/src/wss/handler.ts
+++ b/services/server/src/wss/handler.ts
@@ -89,6 +89,7 @@ export class WssHandler {
         userId: user.id, 
         callId
       });
+      // TODO: check the time of the call
       if (!canJoin) throw Error("Forbidden");
 
       await controllers.calls.joinMemberToCall({

--- a/services/server/tests/wss/call.test.ts
+++ b/services/server/tests/wss/call.test.ts
@@ -1,5 +1,5 @@
 import { Api } from "@fixtures/api";
-import db, { flush, interview } from "@fixtures/db";
+import { flush } from "@fixtures/db";
 import { ClientSocket } from "@fixtures/wss";
 import { IUser, Wss } from "@litespace/types";
 import dayjs from "@/lib/dayjs";
@@ -8,7 +8,7 @@ import { Time } from "@litespace/sol/time";
 import { faker } from "@faker-js/faker/locale/ar";
 import { unpackRules } from "@litespace/sol/rule";
 import { expect } from "chai";
-import { calls } from "@litespace/models";
+import { controllers } from "@/controllers";
 
 describe("calls test suite", () => {
   let tutor: IUser.LoginApiResponse;
@@ -68,8 +68,8 @@ describe("calls test suite", () => {
     tutorSocket.joinCall(lesson.callId, "lesson");
 
     const { userId } = await studentResult;
+    const callMembers = await controllers.calls.getJoinedMembers(lesson.callId);
 
-    const callMembers = await calls.findCallMembers([lesson.callId]);
     expect(callMembers).to.be.of.length(1);
     expect(callMembers[0].userId).to.be.eq(tutor.user.id);
     expect(userId).to.be.eq(tutor.user.id);
@@ -78,14 +78,12 @@ describe("calls test suite", () => {
     studentSocket.joinCall(lesson.callId, "lesson");
 
     const { userId: studentId } = await tutorResult;
-    const callMembersSecondSnapshot = await calls.findCallMembers([
-      lesson.callId,
-    ]);
+    const callMembersSecondSnapshot = await controllers.calls.getJoinedMembers(lesson.callId);
+
     expect(callMembersSecondSnapshot).to.be.of.length(2);
     expect(
       callMembersSecondSnapshot.map((member) => member.userId)
     ).to.be.members([student.user.id, tutor.user.id]);
-
     expect(studentId).to.be.eq(student.user.id);
 
     tutorSocket.client.disconnect();


### PR DESCRIPTION
- The call class (radis controller) has been implemented.
- radis data seeded (for only call table),
- server handlers now works with radis,
- server tests pass,
- and initial implementation for frontend hooks appertain to call members added; radis server synchronously reflects actual members in calls (on each user join and leave). 