### PR TITLE
fix: minor errors and bugs have been fixed. In the user update handler and chat messages functionality.

### DIFF
--- a/apps/web/src/pages/Root.tsx
+++ b/apps/web/src/pages/Root.tsx
@@ -90,7 +90,7 @@ const Root: React.FC = () => {
   }, [location.pathname, params]);
 
   const fullScreenPage = useMemo(() => {
-    const routes: Web[] = [Web.Lesson, Web.LessonV2, Web.LessonV3];
+    const routes: Web[] = [Web.Lesson];
     return routes.some((route) => router.match(route, location.pathname));
   }, [location.pathname]);
 

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -155,8 +155,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                   "text-success-600": state === "success",
                   // Error
                   "text-destructive-600": state === "error",
-                  // Disabled
-                  "text-natural-500": disabled,
                 })}
               >
                 {helper}

--- a/services/server/src/handlers/user.ts
+++ b/services/server/src/handlers/user.ts
@@ -347,6 +347,9 @@ function update(_: ApiContext) {
 
       // remove assets ids from the database / update user data
       const updated = await knex.transaction(async (tx: Knex.Transaction) => {
+        const newEmail = email && email !== target.email;
+        const newPhone = phone && phone !== target.phone;
+
         const updateUserPayload: IUser.UpdatePayloadModel = {
           city,
           name,
@@ -356,13 +359,13 @@ function update(_: ApiContext) {
           image,
           email,
           // reset user verification status incase his email or phone got updated.
-          verifiedEmail: email ? false : undefined,
-          verifiedPhone: phone ? false : undefined,
-          verifiedTelegram: phone ? false : undefined,
-          verifiedWhatsApp: phone ? false : undefined,
+          verifiedEmail: newEmail ? false : undefined,
+          verifiedPhone: newPhone ? false : undefined,
+          verifiedTelegram: newPhone ? false : undefined,
+          verifiedWhatsApp: newPhone ? false : undefined,
           password: password ? hashPassword(password.new) : undefined,
           // reset notification method incase the user phone got updated
-          notificationMethod: phone ? null : notificationMethod,
+          notificationMethod: newPhone ? null : notificationMethod,
         };
 
         const updated = await users.update(id, updateUserPayload, tx);


### PR DESCRIPTION
Fixes:
- An error has been fixed in the user API update handler; the user `verifiedEmail`, ``verifiedPhone and `notificationMethod` field were being reseted on every update request (with the exact old phone/email in the payload).
- A bug in the `sendMessage` function in the headless package has been fixed; the first received message and the first activated message were holding the same `refId`, so `uniqueId` function shall be used in `sendMessage` as well as `activateMessage`.

Enhancements:
- UX/UI: the helper of the `input` component (in the UI package) is no longer colored gray when the input is disabled; error helpers are used even with disabled inputs, as in the `CompleteTutorProfile` page, and the red color makes it noticeable.