### PR TITLE
fix: api connection to redis has been fixed.

### DIFF
--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -6,7 +6,7 @@ PG_HOST='localhost'
 PG_PORT='5432'
 PG_DATABASE='litespace'
 DATABASE_URL=postgres://postgres:litespace@localhost:5432/litespace
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://127.0.0.1:6379
 
 JWT_SECRET='jwt_secret'
 GOOGLE_CLIENT_ID='834919948951-b6chqicfhneibafa40iqg9ccs5611o2n.apps.googleusercontent.com'

--- a/services/server/src/constants.ts
+++ b/services/server/src/constants.ts
@@ -37,10 +37,7 @@ export const databaseConnection = {
 
 export const redisUrl = zod
   .string({ message: "Missing or invalid redis url" })
-  .regex(
-    /^redis:\/\/\w+:\d+/,
-    "Provided redis url doesn't match the expected format `redis://<host>:<port>`"
-  )
+  .startsWith("redis://")
   .parse(process.env.REDIS_URL);
 
 // Server


### PR DESCRIPTION
A tedious error occurred after modifying the docker compose file network traffic ports; API connection to Redis no longer can be established. It has been solved by using `redis://127.0.0.1:{port}` instead of `redis://localhost:{port}`.