### PR TITLE
refactor: zod schemas and api types have been coupled.

### DIFF
--- a/apps/web/src/components/VerifyNotificationMethodDialog/VerifyNotificationMethodDialog.tsx
+++ b/apps/web/src/components/VerifyNotificationMethodDialog/VerifyNotificationMethodDialog.tsx
@@ -13,10 +13,10 @@ type Props = {
   close: Void;
   method: IUser.NotificationMethodLiteral | null;
   phone: string | null;
-  sendCode: (payload: IConfirmationCode.SendVerifyPhoneCodePayload) => void;
+  sendCode: (payload: IConfirmationCode.SendVerifyPhoneCodeApiPayload) => void;
   sendingCode: boolean;
   sentCode: boolean;
-  verifyCode: (payload: IConfirmationCode.VerifyPhoneCodePayload) => void;
+  verifyCode: (payload: IConfirmationCode.VerifyPhoneCodeApiPayload) => void;
   verifing: boolean;
   unresolvedPhone: boolean;
 };

--- a/apps/web/src/components/VerifyPhoneDialog/VerifyCode.tsx
+++ b/apps/web/src/components/VerifyPhoneDialog/VerifyCode.tsx
@@ -15,7 +15,7 @@ type Props = {
   resending: boolean;
   verifing: boolean;
   method: IUser.NotificationMethodLiteral;
-  verifyCode: (payload: IConfirmationCode.VerifyPhoneCodePayload) => void;
+  verifyCode: (payload: IConfirmationCode.VerifyPhoneCodeApiPayload) => void;
   close: Void;
 };
 

--- a/apps/web/src/components/VerifyPhoneDialog/VerifyPhoneDialog.tsx
+++ b/apps/web/src/components/VerifyPhoneDialog/VerifyPhoneDialog.tsx
@@ -13,11 +13,11 @@ type Props = {
   open: boolean;
   close: Void;
   phone: string | null;
-  sendCode(payload: IConfirmationCode.SendVerifyPhoneCodePayload): void;
+  sendCode(payload: IConfirmationCode.SendVerifyPhoneCodeApiPayload): void;
   sendingCode: boolean;
   sentCode: boolean;
   unresolvedPhone: boolean;
-  verifyCode(payload: IConfirmationCode.VerifyPhoneCodePayload): void;
+  verifyCode(payload: IConfirmationCode.VerifyPhoneCodeApiPayload): void;
   verifyingCode: boolean;
 };
 

--- a/packages/atlas/src/api/confirmationCode.ts
+++ b/packages/atlas/src/api/confirmationCode.ts
@@ -3,7 +3,7 @@ import { IConfirmationCode } from "@litespace/types";
 
 export class ConfirmationCode extends Base {
   async sendVerifyPhoneCode(
-    payload: IConfirmationCode.SendVerifyPhoneCodePayload
+    payload: IConfirmationCode.SendVerifyPhoneCodeApiPayload
   ): Promise<void> {
     return await this.post({
       route: `/api/v1/confirmation-code/phone/send`,
@@ -12,7 +12,7 @@ export class ConfirmationCode extends Base {
   }
 
   async verifyPhoneCode(
-    payload: IConfirmationCode.VerifyPhoneCodePayload
+    payload: IConfirmationCode.VerifyPhoneCodeApiPayload
   ): Promise<void> {
     return await this.post({
       route: `/api/v1/confirmation-code/phone/verify`,
@@ -21,7 +21,7 @@ export class ConfirmationCode extends Base {
   }
 
   async confirmVerificationEmailCode(
-    payload: IConfirmationCode.VerifyEmailPayload
+    payload: IConfirmationCode.VerifyEmailApiPayload
   ): Promise<void> {
     await this.post({
       route: "/api/v1/confirmation-code/email/confirm",
@@ -36,7 +36,7 @@ export class ConfirmationCode extends Base {
   }
 
   async confirmForgetPasswordCode(
-    payload: IConfirmationCode.ConfirmForgetPasswordCodePayload
+    payload: IConfirmationCode.ConfirmForgetPasswordCodeApiPayload
   ): Promise<IConfirmationCode.ConfirmPasswordCodeApiResponse> {
     await this.post({
       route: "/api/v1/confirmation-code/password/confirm",
@@ -45,7 +45,7 @@ export class ConfirmationCode extends Base {
   }
 
   async sendForgetPasswordCode(
-    payload: IConfirmationCode.SendForgetPasswordEmailPayload
+    payload: IConfirmationCode.SendForgetPasswordEmailApiPayload
   ): Promise<void> {
     await this.post({
       route: "/api/v1/confirmation-code/password/send",

--- a/packages/atlas/src/api/topic.ts
+++ b/packages/atlas/src/api/topic.ts
@@ -3,7 +3,7 @@ import { ITopic } from "@litespace/types";
 
 export class Topic extends Base {
   async create(
-    payload: ITopic.CreateApiPayload
+    payload: ITopic.CreateTopicApiPayload
   ): Promise<ITopic.CreateTopicApiResponse> {
     return await this.post({ route: "/api/v1/topic/", payload });
   }

--- a/packages/atlas/src/api/transaction.ts
+++ b/packages/atlas/src/api/transaction.ts
@@ -7,7 +7,7 @@ export class Transaction extends Base {
   }
 
   async find(
-    payload?: ITransaction.FindQueryApi
+    payload?: ITransaction.FindApiQuery
   ): Promise<ITransaction.FindApiResponse> {
     return this.get({ route: `/api/v1/tx/list`, payload: payload });
   }

--- a/packages/atlas/src/api/user.ts
+++ b/packages/atlas/src/api/user.ts
@@ -109,7 +109,7 @@ export class User extends Base {
   }
 
   async findOnboardedTutors(
-    params?: ITutor.FindOnboardedTutorsParams
+    params?: ITutor.FindOnboardedTutorsQuery
   ): Promise<ITutor.FindOnboardedTutorsApiResponse> {
     return await this.get({
       route: `/api/v1/user/tutor/list/onboarded`,

--- a/packages/headless/src/confirmationCode.ts
+++ b/packages/headless/src/confirmationCode.ts
@@ -15,7 +15,7 @@ export function useSendPhoneCode({
   const api = useApi();
 
   const sendPhoneCode = useCallback(
-    (payload: IConfirmationCode.SendVerifyPhoneCodePayload) =>
+    (payload: IConfirmationCode.SendVerifyPhoneCodeApiPayload) =>
       api.confirmationCode.sendVerifyPhoneCode(payload),
     [api]
   );
@@ -38,7 +38,7 @@ export function useVerifyPhoneCode({
   const api = useApi();
 
   const verifyPhoneCode = useCallback(
-    (payload: IConfirmationCode.VerifyPhoneCodePayload) =>
+    (payload: IConfirmationCode.VerifyPhoneCodeApiPayload) =>
       api.confirmationCode.verifyPhoneCode(payload),
     [api]
   );
@@ -61,7 +61,7 @@ export function useSendForgetPasswordCode({
   const api = useApi();
 
   const sendCode = useCallback(
-    (payload: IConfirmationCode.SendForgetPasswordEmailPayload) => {
+    (payload: IConfirmationCode.SendForgetPasswordEmailApiPayload) => {
       return api.confirmationCode.sendForgetPasswordCode(payload);
     },
     [api.confirmationCode]
@@ -85,7 +85,7 @@ export function useConfirmForgetPasswordCode({
   const api = useApi();
 
   const send = useCallback(
-    (payload: IConfirmationCode.ConfirmForgetPasswordCodePayload) => {
+    (payload: IConfirmationCode.ConfirmForgetPasswordCodeApiPayload) => {
       return api.confirmationCode.confirmForgetPasswordCode(payload);
     },
     [api.confirmationCode]

--- a/packages/headless/src/topic.ts
+++ b/packages/headless/src/topic.ts
@@ -19,7 +19,7 @@ export function useCreateTopic({
   const api = useApi();
 
   const createTopic = useCallback(
-    async (payload: ITopic.CreateApiPayload) => {
+    async (payload: ITopic.CreateTopicApiPayload) => {
       return api.topic.create(payload);
     },
     [api.topic]

--- a/packages/types/src/confirmationCode.ts
+++ b/packages/types/src/confirmationCode.ts
@@ -38,31 +38,31 @@ export type FindPayloadModel = {
   purpose?: Purpose;
 };
 
-export type SendVerifyPhoneCodePayload = {
+export type SendVerifyPhoneCodeApiPayload = {
   phone?: string;
   method: IUser.NotificationMethodLiteral;
 };
 
-export type VerifyPhoneCodePayload = {
+export type VerifyPhoneCodeApiPayload = {
   code: number;
   method: IUser.NotificationMethodLiteral;
 };
 
-export type SendForgetPasswordEmailPayload = {
+export type SendForgetPasswordEmailApiPayload = {
   email: string;
 };
 
-export type SendVerifyEmailPayload = {
+export type SendVerifyEmailApiPayload = {
   email: string;
 };
 
-export type ConfirmForgetPasswordCodePayload = {
+export type ConfirmForgetPasswordCodeApiPayload = {
   password: string;
   code: number;
 };
 
 export type ConfirmPasswordCodeApiResponse = void;
 
-export type VerifyEmailPayload = {
+export type VerifyEmailApiPayload = {
   code: number;
 };

--- a/packages/types/src/fawry.ts
+++ b/packages/types/src/fawry.ts
@@ -24,6 +24,8 @@ export type OrderStatus =
   | "PARTIAL_REFUNDED"
   | "FAILED";
 
+export type PaymentMethod = "CARD" | "MWALLET" | "PAYATFAWRY" | "Mobile Wallet";
+
 export type PayWithCardPayload = {
   phone?: string;
   planId: number;

--- a/packages/types/src/invite.ts
+++ b/packages/types/src/invite.ts
@@ -52,3 +52,7 @@ export type UpdatePayload = Partial<Omit<CreatePayload, "createdBy">> & {
 export type CreateApiPayload = Omit<CreatePayload, "createdBy">;
 
 export type UpdateApiPayload = Omit<UpdatePayload, "updatedBy">;
+
+export type FindByEmailApiPayload = {
+  email: string;
+};

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -3,6 +3,10 @@ import { ISession } from ".";
 export type Type = "lesson" | "interview";
 export type Id = `${Type}:${string}`;
 
+export type FindSessionMembersApiParams = {
+  sessionId: Id;
+};
+
 export type FindSessionMembersApiResponse = number[];
 
 export type GetSessionTokenApiResponse = {

--- a/packages/types/src/topic.ts
+++ b/packages/types/src/topic.ts
@@ -50,9 +50,14 @@ export type CreateUserTopicsPayload = {
   topics: number[];
 };
 
-export type CreateApiPayload = {
+export type CreateTopicApiPayload = {
   arabicName: string;
   englishName: string;
+};
+
+export type UpdateTopicApiPayload = {
+  arabicName?: string;
+  englishName?: string;
 };
 
 /**

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -71,7 +71,7 @@ export type FindFilterModel = {
 
 export type FindQueryModel = IFilter.SkippablePagination & FindFilterModel;
 
-export type FindQueryApi = FindQueryModel;
+export type FindApiQuery = FindQueryModel;
 
 export type FindApiResponse = Paginated<Self>;
 

--- a/packages/types/src/tutor.ts
+++ b/packages/types/src/tutor.ts
@@ -105,7 +105,7 @@ export type FullUncontactedTutorInfo = UncontactedTutorInfo & {
   online: boolean;
 };
 
-export type FindOnboardedTutorsParams = IFilter.Pagination & {
+export type FindOnboardedTutorsQuery = IFilter.Pagination & {
   /**
    * Search keyword to filter out tutors and topics.
    */

--- a/services/server/src/handlers/availabilitySlot.ts
+++ b/services/server/src/handlers/availabilitySlot.ts
@@ -12,7 +12,7 @@ import { availabilitySlots, knex } from "@litespace/models";
 import dayjs from "@/lib/dayjs";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import { isEmpty } from "lodash";
 import {
   deleteSlots,
@@ -22,36 +22,38 @@ import {
 } from "@/lib/availabilitySlot";
 import { MAX_FULL_FLAG_DAYS } from "@/constants";
 
-const findPayload = zod.object({
-  userId: id,
-  after: datetime.optional(),
-  before: datetime.optional(),
-  page: pageNumber.optional(),
-  size: pageSize.optional(),
-  full: jsonBoolean.optional(),
-});
+const findQuery: ZodSchema<IAvailabilitySlot.FindAvailabilitySlotsApiQuery> =
+  zod.object({
+    userId: id,
+    after: datetime.optional(),
+    before: datetime.optional(),
+    page: pageNumber.optional(),
+    size: pageSize.optional(),
+    full: jsonBoolean.optional(),
+  });
 
-const setPayload = zod.object({
-  actions: zod.array(
-    zod.union([
-      zod.object({
-        type: zod.literal("create"),
-        start: datetime,
-        end: datetime,
-      }),
-      zod.object({
-        type: zod.literal("update"),
-        id: id,
-        start: datetime.optional(),
-        end: datetime.optional(),
-      }),
-      zod.object({
-        type: zod.literal("delete"),
-        id: id,
-      }),
-    ])
-  ),
-});
+const setPayload: ZodSchema<IAvailabilitySlot.SetAvailabilitySlotsApiPayload> =
+  zod.object({
+    actions: zod.array(
+      zod.union([
+        zod.object({
+          type: zod.literal("create"),
+          start: datetime,
+          end: datetime,
+        }),
+        zod.object({
+          type: zod.literal("update"),
+          id: id,
+          start: datetime.optional(),
+          end: datetime.optional(),
+        }),
+        zod.object({
+          type: zod.literal("delete"),
+          id: id,
+        }),
+      ])
+    ),
+  });
 
 async function find(req: Request, res: Response, next: NextFunction) {
   const user = req.user;
@@ -64,7 +66,7 @@ async function find(req: Request, res: Response, next: NextFunction) {
     page,
     size,
     full,
-  }: IAvailabilitySlot.FindAvailabilitySlotsApiQuery = findPayload.parse(
+  }: IAvailabilitySlot.FindAvailabilitySlotsApiQuery = findQuery.parse(
     req.query
   );
 

--- a/services/server/src/handlers/chat.ts
+++ b/services/server/src/handlers/chat.ts
@@ -2,7 +2,7 @@ import { knex, messages, rooms, users } from "@litespace/models";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
 import { isEmpty } from "lodash";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import {
   id,
   pagination,
@@ -24,12 +24,17 @@ import { asFindUserRoomsApiRecord } from "@/lib/chat";
 import { cache } from "@/lib/cache";
 import { withImageUrls } from "@/lib/user";
 
-const createRoomPayload = zod.object({
+const createRoomPayload: ZodSchema<IRoom.CreateRoomApiPayload> = zod.object({
   userId: id,
   message: zod.optional(zod.string()),
 });
-const findRoomByMembersPayload = zod.object({ members: zod.array(id) });
-const findUserRoomsQuery = zod.object({
+
+const findRoomByMembersPayload: ZodSchema<IRoom.FindRoomByMembersApiPayload> =
+  zod.object({
+    members: zod.array(id),
+  });
+
+const findUserRoomsQuery: ZodSchema<IRoom.FindUserRoomsApiQuery> = zod.object({
   page: zod.optional(pageNumber),
   size: zod.optional(pageSize),
   pinned: zod.optional(jsonBoolean),
@@ -37,7 +42,7 @@ const findUserRoomsQuery = zod.object({
   keyword: zod.optional(zod.string()),
 });
 
-const updateRoomPayload = zod.object({
+const updateRoomPayload: ZodSchema<IRoom.UpdateRoomApiPayload> = zod.object({
   pinned: zod.optional(zod.boolean()),
   muted: zod.optional(zod.boolean()),
 });

--- a/services/server/src/handlers/contactRequest.ts
+++ b/services/server/src/handlers/contactRequest.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import { string } from "@/validation/utils";
 import safeRequest from "express-async-handler";
 import { IContactRequest } from "@litespace/types";
@@ -15,12 +15,13 @@ import {
 } from "@litespace/utils";
 import { apierror } from "@/lib/error";
 
-const createPayload = zod.object({
-  name: string,
-  phone: string,
-  title: string,
-  message: string,
-});
+const createPayload: ZodSchema<IContactRequest.CreateContactRequestApiPayload> =
+  zod.object({
+    name: string,
+    phone: string,
+    title: string,
+    message: string,
+  });
 
 async function create(req: Request, res: Response, next: NextFunction) {
   const payload: IContactRequest.CreatePayload = createPayload.parse(req.body);

--- a/services/server/src/handlers/coupon.ts
+++ b/services/server/src/handlers/coupon.ts
@@ -10,10 +10,10 @@ import {
 import { ICoupon } from "@litespace/types";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import { isAdmin } from "@litespace/utils/user";
 
-const createCouponPayload = zod.object({
+const createCouponPayload: ZodSchema<ICoupon.CreateApiPayload> = zod.object({
   code: string,
   planId: number,
   fullMonthDiscount: number,
@@ -23,7 +23,7 @@ const createCouponPayload = zod.object({
   expiresAt: datetime,
 });
 
-const updateCouponPayload = zod.object({
+const updateCouponPayload: ZodSchema<ICoupon.UpdateApiPayload> = zod.object({
   code: zod.optional(string),
   planId: zod.optional(number),
   fullMonthDiscount: zod.optional(number),

--- a/services/server/src/handlers/fawry.ts
+++ b/services/server/src/handlers/fawry.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 
 import {
   isAdmin,
@@ -51,7 +51,7 @@ const planPeroid = unionOfLiterals<IPlan.PeriodLiteral>([
   "year",
 ]);
 
-const payWithCardPayload = zod.object({
+const payWithCardPayload: ZodSchema<IFawry.PayWithCardPayload> = zod.object({
   planId: id,
   cardToken: zod.string(),
   period: planPeroid,
@@ -59,51 +59,60 @@ const payWithCardPayload = zod.object({
   phone: zod.string().optional(),
 });
 
-const payWithRefNumPayload = zod.object({
-  planId: id,
-  period: planPeroid,
-  phone: zod.string().optional(),
-});
+const payWithRefNumPayload: ZodSchema<IFawry.PayWithRefNumPayload> = zod.object(
+  {
+    planId: id,
+    period: planPeroid,
+    phone: zod.string().optional(),
+  }
+);
 
-const payWithEWalletPayload = zod.object({
-  planId: id,
-  period: planPeroid,
-  wallet: zod.string(),
-  phone: zod.string().optional(),
-});
+const payWithEWalletPayload: ZodSchema<IFawry.PayWithEWalletPayload> =
+  zod.object({
+    planId: id,
+    period: planPeroid,
+    wallet: zod.string(),
+    phone: zod.string().optional(),
+  });
 
-const payWithBankInstallmentsPayload = zod.object({
-  planId: zod.number(),
-  amount: zod.number(),
-  cardToken: zod.string(),
-  cvv: zod.number(),
-  returnUrl: zod.string(),
-});
+const payWithBankInstallmentsPayload: ZodSchema<IFawry.PayWithBankInstallmentsPayload> =
+  zod.object({
+    planId: zod.number(),
+    amount: zod.number(),
+    cardToken: zod.string(),
+    cvv: zod.number(),
+    returnUrl: zod.string(),
+  });
 
-const cancelUnpaidOrderPayload = zod.object({
-  transactionId: id,
-});
+const cancelUnpaidOrderPayload: ZodSchema<IFawry.CancelUnpaidOrderPayload> =
+  zod.object({
+    transactionId: id,
+  });
 
-const syncPaymentPayload = zod.object({ transactionId: id });
+const syncPaymentPayload: ZodSchema<IFawry.SyncPaymentStatusPayload> =
+  zod.object({ transactionId: id });
 
-const refundPayload = zod.object({
+const refundPayload: ZodSchema<IFawry.RefundPayload> = zod.object({
   orderRefNum: zod.string(),
   refundAmount: zod.number(),
   reason: zod.string().optional(),
 });
 
-const findCardTokensQueryPayload = zod.object({
-  userId: id,
-});
+const findCardTokensQuery: ZodSchema<IFawry.FindCardTokensApiQuery> =
+  zod.object({
+    userId: id,
+  });
 
-const deleteCardTokenPayload = zod.object({
-  cardToken: zod.string(),
-  userId: id,
-});
+const deleteCardTokenPayload: ZodSchema<IFawry.DeleteCardTokenPayload> =
+  zod.object({
+    cardToken: zod.string(),
+    userId: id,
+  });
 
-const getPaymentStatusPayload = zod.object({
-  transactionId: id,
-});
+const getPaymentStatusPayload: ZodSchema<IFawry.GetPaymentStatusPayload> =
+  zod.object({
+    transactionId: id,
+  });
 
 const setPaymentStatusPayload = zod.object({
   requestId: zod.string(),
@@ -491,8 +500,9 @@ async function findCardTokens(req: Request, res: Response, next: NextFunction) {
   const allowed = isStudent(user) || isAdmin(user);
   if (!allowed) return next(forbidden());
 
-  const { userId }: IFawry.FindCardTokensApiQuery =
-    findCardTokensQueryPayload.parse(req.query);
+  const { userId }: IFawry.FindCardTokensApiQuery = findCardTokensQuery.parse(
+    req.query
+  );
   if (isStudent(user) && userId !== user.id) return next(forbidden());
 
   const result = await fawry.findCardTokens(userId);

--- a/services/server/src/handlers/interview.ts
+++ b/services/server/src/handlers/interview.ts
@@ -55,7 +55,7 @@ const createPayload: ZodSchema<IInterview.CreateApiPayload> = zod.object({
   slotId: id,
 });
 
-const findQuery = zod.object({
+const findQuery: ZodSchema<IInterview.FindApiQuery> = zod.object({
   ids: ids.describe("filter by interview id").optional(),
   userss: ids.describe("filter by user ids").optional(),
   interviewers: ids.describe("filter by interviewer ids").optional(),

--- a/services/server/src/handlers/invite.ts
+++ b/services/server/src/handlers/invite.ts
@@ -9,22 +9,25 @@ import {
 } from "@/validation/utils";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import { isAdmin, isStudent } from "@litespace/utils/user";
+import { IInvite } from "@litespace/types";
 
-const createInvitePayload = zod.object({
+const createInvitePayload: ZodSchema<IInvite.CreateApiPayload> = zod.object({
   email,
   planId: id,
   expiresAt: datetime,
 });
 
-const updateInvitePayload = zod.object({
+const updateInvitePayload: ZodSchema<IInvite.UpdateApiPayload> = zod.object({
   email: zod.optional(email),
   planId: zod.optional(id),
   expiresAt: zod.optional(datetime),
 });
 
-const findByEmailPayload = zod.object({ email: email });
+const findByEmailPayload: ZodSchema<IInvite.FindByEmailApiPayload> = zod.object(
+  { email: email }
+);
 
 async function createInvite(req: Request, res: Response, next: NextFunction) {
   const user = req.user;

--- a/services/server/src/handlers/invoice.ts
+++ b/services/server/src/handlers/invoice.ts
@@ -22,7 +22,7 @@ import { invoices, lessons } from "@litespace/models";
 import { IInvoice, IUser, Wss } from "@litespace/types";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import {
   isValidInvoiceAmount,
   isValidInvoiceNote,
@@ -30,14 +30,14 @@ import {
 } from "@litespace/utils";
 import bytes from "bytes";
 
-const createPayload = zod.object({
+const createPayload: ZodSchema<IInvoice.CreateApiPayload> = zod.object({
   method: withdrawMethod,
   receiver: zod.string(),
   amount: zod.coerce.number().int().positive(),
   note: zod.optional(zod.string()),
 });
 
-const updatePayload = zod.object({
+const updatePayload: ZodSchema<IInvoice.UpdateApiPayload> = zod.object({
   status: zod.optional(zod.nativeEnum(IInvoice.Status)),
   note: zod.optional(zod.string()),
 });
@@ -48,7 +48,7 @@ const orderByOptions = [
   "amount",
 ] as const satisfies Array<IInvoice.FindInvoicesQuery["orderBy"]>;
 
-const findPayload = zod.object({
+const findQuery: ZodSchema<IInvoice.FindInvoicesQuery> = zod.object({
   users: zod.optional(ids),
   methods: zod.optional(zod.array(withdrawMethod)),
   statuses: zod.optional(zod.array(invoiceStatus)),
@@ -229,7 +229,7 @@ function update(context: ApiContext) {
 
 async function find(req: Request, res: Response, next: NextFunction) {
   const user = req.user;
-  const query: IInvoice.FindInvoicesQuery = findPayload.parse(req.query);
+  const query: IInvoice.FindInvoicesQuery = findQuery.parse(req.query);
   const itsTutor = isRegularTutor(user);
   const allowed = itsTutor || isAdmin(user);
   if (!allowed) return next(forbidden());

--- a/services/server/src/handlers/lesson.ts
+++ b/services/server/src/handlers/lesson.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import {
   datetime,
   duration,
@@ -50,21 +50,21 @@ import { calculateRemainingWeeklyMinutesOfCurrentWeekBySubscription } from "@/li
 import { getCurrentWeekBoundaries } from "@litespace/utils/subscription";
 import { getDayLessonsMap, inflateDayLessonsMap } from "@/lib/lesson";
 
-const createLessonPayload = zod.object({
+const createLessonPayload: ZodSchema<ILesson.CreateApiPayload> = zod.object({
   tutorId: id,
   slotId: id,
   start: datetime,
   duration,
 });
 
-const updateLessonPayload = zod.object({
+const updateLessonPayload: ZodSchema<ILesson.UpdateApiPayload> = zod.object({
   lessonId: id,
   slotId: id,
   start: datetime,
   duration: duration,
 });
 
-const findLessonsQuery = zod.object({
+const findLessonsQuery: ZodSchema<ILesson.FindLessonsApiQuery> = zod.object({
   users: zod.optional(zod.array(id)),
   page: zod.optional(pageNumber),
   size: zod.optional(pageSize),

--- a/services/server/src/handlers/plan.ts
+++ b/services/server/src/handlers/plan.ts
@@ -14,12 +14,12 @@ import { IPlan } from "@litespace/types";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
 import { isRegularUser, isSuperAdmin, isUser } from "@litespace/utils/user";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 
 const number = zod.number().int().positive().gt(0);
-const discount = zod.number().int().gte(0).default(0);
+const discount = zod.number().int().gte(0);
 
-const createPlanPayload = zod.object({
+const createPlanPayload: ZodSchema<IPlan.CreateApiPayload> = zod.object({
   weeklyMinutes: number,
   baseMonthlyPrice: number,
   monthDiscount: discount,
@@ -29,7 +29,7 @@ const createPlanPayload = zod.object({
   active: boolean,
 });
 
-const updatePlanPayload = zod.object({
+const updatePlanPayload: ZodSchema<IPlan.UpdateApiPayload> = zod.object({
   weeklyMinutes: zod.optional(number),
   baseMonthlyPrice: zod.optional(number),
   monthDiscount: zod.optional(number),
@@ -39,7 +39,7 @@ const updatePlanPayload = zod.object({
   active: zod.optional(boolean),
 });
 
-const findPlansQuery = zod.object({
+const findPlansQuery: ZodSchema<IPlan.FindApiQuery> = zod.object({
   ids: id.array().optional().describe("fild plans by ids"),
   weeklyMinutes: numericFilter
     .optional()

--- a/services/server/src/handlers/rating.ts
+++ b/services/server/src/handlers/rating.ts
@@ -18,15 +18,15 @@ import {
   isTutor,
   isUser,
 } from "@litespace/utils/user";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 
-const createRatingPayload = zod.object({
+const createRatingPayload: ZodSchema<IRating.CreateApiPayload> = zod.object({
   rateeId: id,
   value: rating,
   feedback: zod.union([zod.null(), zod.string()]),
 });
 
-const updateRatingPayload = zod.object({
+const updateRatingPayload: ZodSchema<IRating.UpdateApiPayload> = zod.object({
   value: zod.optional(rating),
   feedback: zod.optional(string),
 });

--- a/services/server/src/handlers/session.ts
+++ b/services/server/src/handlers/session.ts
@@ -9,11 +9,13 @@ import safeRequest from "express-async-handler";
 import { AccessToken } from "livekit-server-sdk";
 import { livekitConfig } from "@/constants";
 import { sessionId } from "@/validation/utils";
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 
-const findSessionMembersParams = zod.object({ sessionId });
+const findSessionMembersParams: ZodSchema<ISession.FindSessionMembersApiParams> =
+  zod.object({ sessionId });
 
-const getSessionTokenQuery = zod.object({ sessionId });
+const getSessionTokenQuery: ZodSchema<ISession.GetSessionTokenApiQuery> =
+  zod.object({ sessionId });
 
 async function findSessionMembers(
   req: Request,

--- a/services/server/src/handlers/subscription.ts
+++ b/services/server/src/handlers/subscription.ts
@@ -1,4 +1,4 @@
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import { IPlan, ISubscription } from "@litespace/types";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
@@ -16,7 +16,7 @@ import dayjs from "@/lib/dayjs";
 import { first } from "lodash";
 import { calculateRemainingWeeklyMinutesOfCurrentWeekBySubscription } from "@/lib/subscription";
 
-const findQuery = zod.object({
+const findQuery: ZodSchema<ISubscription.FindApiQuery> = zod.object({
   ids: id.array().optional(),
   users: id.array().optional(),
   plans: id.array().optional(),
@@ -48,9 +48,10 @@ const findQuery = zod.object({
   size: pageSize.optional().default(10),
 });
 
-const findUserSubscriptionQuery = zod.object({
-  userId: id,
-});
+const findUserSubscriptionQuery: ZodSchema<ISubscription.FindUserSubscriptionApiQuery> =
+  zod.object({
+    userId: id,
+  });
 
 async function find(req: Request, res: Response, next: NextFunction) {
   const user = req.user;

--- a/services/server/src/handlers/transaction.ts
+++ b/services/server/src/handlers/transaction.ts
@@ -1,4 +1,4 @@
-import zod from "zod";
+import zod, { ZodSchema } from "zod";
 import { ITransaction } from "@litespace/types";
 import { NextFunction, Request, Response } from "express";
 import safeRequest from "express-async-handler";
@@ -8,7 +8,7 @@ import { isAdmin, isStudent } from "@litespace/utils/user";
 import { transactions } from "@litespace/models";
 import { first } from "lodash";
 
-const findPayload = zod.object({
+const findPayload: ZodSchema<ITransaction.FindApiQuery> = zod.object({
   ids: id.array().optional(),
   users: id.array().optional(),
   amount: zod.number().min(0).optional(),
@@ -26,7 +26,7 @@ async function find(req: Request, res: Response, next: NextFunction) {
   const allowed = isAdmin(user) || isStudent(user);
   if (!allowed) return next(forbidden());
 
-  const payload: ITransaction.FindQueryApi = findPayload.parse(req.body);
+  const payload = findPayload.parse(req.body);
 
   const response: ITransaction.FindApiResponse = await transactions.find({
     ...payload,

--- a/services/server/src/validation/utils.ts
+++ b/services/server/src/validation/utils.ts
@@ -39,9 +39,11 @@ export const number = zod.coerce.number();
 
 export const boolean = zod.boolean();
 
-export const jsonBoolean = zod
+// NOTE: the type is coerced to ZodBoolean as the transform function
+// doesn't mutate the type as supposed to.
+export const jsonBoolean: zod.ZodBoolean = zod
   .custom<"true" | "false">((value) => value === "true" || value === "false")
-  .transform((value) => value === "true");
+  .transform((value) => value === "true") as unknown as zod.ZodBoolean;
 
 export const orderDirection = unionOfLiterals<IFilter.Direction>([
   "acs",
@@ -140,6 +142,7 @@ export const numericFilter = zod.union([
     lte: zod.coerce.number().optional(),
     gt: zod.coerce.number().optional(),
     lt: zod.coerce.number().optional(),
+    noeq: zod.coerce.number().optional(),
   }),
 ]);
 
@@ -150,13 +153,18 @@ export const dateFilter = zod.union([
     lte: zod.string().optional(),
     gt: zod.string().optional(),
     lt: zod.string().optional(),
+    noeq: zod.string().optional(),
   }),
 ]);
 
 export const nullableString = zod.union([zod.string(), zod.null()]);
 
-export const queryBoolean = zod
+// NOTE: the type is coerced to ZodBoolean as the transform function
+// doesn't mutate the type as supposed to.
+export const queryBoolean: zod.ZodBoolean = zod
   .custom<
     "true" | "false" | true | false
   >((value) => value === "true" || value === "false" || value === true || value === false)
-  .transform((value) => value === "true" || value === true);
+  .transform(
+    (value) => value === "true" || value === true
+  ) as unknown as zod.ZodBoolean;


### PR DESCRIPTION
All Api types in the `types` package have been used in the server handlers, as follows:
```TS
const createUserPayload: ZodSchema<IUser.CreateApiPayload> = ...
```
