### PR TITLE
fix(landing): the highlight function has been replaced by highlight component

### DIFF
--- a/apps/landing/components/Common/Highlight.tsx
+++ b/apps/landing/components/Common/Highlight.tsx
@@ -1,0 +1,15 @@
+import { useFormatMessage } from "@/hooks/intl";
+import { LocalId } from "@/locales/request";
+import { Typography } from "@litespace/ui/Typography";
+
+export const Highlight: React.FC<{ id: LocalId }> = ({ id }) => {
+  const intl = useFormatMessage();
+
+  return intl.rich(id, {
+    highlight: (chunks) => (
+      <Typography tag="span" className="text-brand-500">
+        {chunks}
+      </Typography>
+    ),
+  });
+};

--- a/apps/landing/components/ContactUs.tsx
+++ b/apps/landing/components/ContactUs.tsx
@@ -14,6 +14,7 @@ import {
   LITESPACE_TUTORS_TELEGRAM,
   LITESPACE_WHATSAPP,
 } from "@/constants/links";
+import { Highlight } from "@/components/Common/Highlight";
 
 const Contacts: React.FC<{ tutor?: boolean }> = ({ tutor }) => {
   const intl = useFormatMessage();
@@ -78,13 +79,7 @@ const ContactUs: React.FC<{ tutor?: boolean }> = ({ tutor }) => {
             tag="h1"
             className="text-natural-950 text-subtitle-2 md:text-h4 font-bold"
           >
-            {intl.rich("contact-us/title", {
-              highlight: (chunks) => (
-                <Typography tag="span" className="text-brand-500">
-                  {chunks}
-                </Typography>
-              ),
-            })}
+            <Highlight id="contact-us/title" />
           </Typography>
           <Typography
             tag="p"

--- a/apps/landing/components/Features/index.tsx
+++ b/apps/landing/components/Features/index.tsx
@@ -1,16 +1,16 @@
-import { highlight, useFormatMessage } from "@/hooks/intl";
+import { useFormatMessage } from "@/hooks/intl";
 import { FeatureProps } from "@/components/Features/types";
 import Feature from "@/components/Features/Feautre";
 import { LottieAnimate } from "@/components/Common/LottieAnimate";
+import { Highlight } from "@/components/Common/Highlight";
 
 export const Features: React.FC = () => {
   const intl = useFormatMessage();
   const features: Array<FeatureProps> = [
     {
       title: intl("home/features/feature/one-on-one/title"),
-      description: highlight(
-        intl,
-        "home/features/feature/one-on-one/description"
+      description: (
+        <Highlight id="home/features/feature/one-on-one/description" />
       ),
       image: (
         <LottieAnimate animation="oneOnOne" className="w-1/2 min-w-[350px]" />
@@ -19,7 +19,7 @@ export const Features: React.FC = () => {
     },
     {
       title: intl("home/features/feature/anytime/title"),
-      description: highlight(intl, "home/features/feature/anytime/description"),
+      description: <Highlight id="home/features/feature/anytime/description" />,
       image: (
         <LottieAnimate animation="anytime" className="w-1/2 min-w-[350px]" />
       ),
@@ -27,9 +27,8 @@ export const Features: React.FC = () => {
     },
     {
       title: intl("home/features/feature/novelity/title"),
-      description: highlight(
-        intl,
-        "home/features/feature/novelity/description"
+      description: (
+        <Highlight id="home/features/feature/novelity/description" />
       ),
       image: (
         <LottieAnimate animation="novelity" className="w-1/2 min-w-[350px]" />
@@ -38,9 +37,8 @@ export const Features: React.FC = () => {
     },
     {
       title: intl("home/features/feature/time-is-yours/title"),
-      description: highlight(
-        intl,
-        "home/features/feature/time-is-yours/description"
+      description: (
+        <Highlight id="home/features/feature/time-is-yours/description" />
       ),
       image: (
         <LottieAnimate
@@ -52,9 +50,8 @@ export const Features: React.FC = () => {
     },
     {
       title: intl("home/features/feature/all-in-english/title"),
-      description: highlight(
-        intl,
-        "home/features/feature/all-in-english/description"
+      description: (
+        <Highlight id="home/features/feature/all-in-english/description" />
       ),
       image: (
         <LottieAnimate
@@ -66,9 +63,8 @@ export const Features: React.FC = () => {
     },
     {
       title: intl("home/features/feature/notifications/title"),
-      description: highlight(
-        intl,
-        "home/features/feature/notifications/description"
+      description: (
+        <Highlight id="home/features/feature/notifications/description" />
       ),
       image: (
         <LottieAnimate

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -1,10 +1,11 @@
-import { highlight, useFormatMessage } from "@/hooks/intl";
+import { useFormatMessage } from "@/hooks/intl";
 import { router } from "@/lib/routes";
 import { Button } from "@litespace/ui/Button";
 import { Typography } from "@litespace/ui/Typography";
 import { Web } from "@litespace/utils/routes";
 import cn from "classnames";
 import Link from "@/components/Common/Link";
+import { Highlight } from "@/components/Common/Highlight";
 import { LottieAnimate } from "@/components/Common/LottieAnimate";
 
 const Hero: React.FC = () => {
@@ -23,13 +24,13 @@ const Hero: React.FC = () => {
             tag="h1"
             className="text-natural-950 text-subtitle-1 md:text-h2 font-bold lg:w-full"
           >
-            {highlight(intl, "home/hero/title")}
+            <Highlight id="home/hero/title" />
           </Typography>
           <Typography
             tag="p"
             className="text-natural-700 text-body md:text-subtitle-2 font-medium lg:w-full"
           >
-            {highlight(intl, "home/hero/description")}
+            <Highlight id="home/hero/description" />
           </Typography>
         </div>
         <Link

--- a/apps/landing/components/Tutors/index.tsx
+++ b/apps/landing/components/Tutors/index.tsx
@@ -4,14 +4,12 @@ import Content from "@/components/Tutors/Content";
 import { Typography } from "@litespace/ui/Typography";
 import React from "react";
 import InViewTrack from "@/components/Common/InViewTrack";
-import { highlight, useFormatMessage } from "@/hooks/intl";
 import { ITutor } from "@litespace/types";
+import { Highlight } from "@/components/Common/Highlight";
 
 export const Tutors: React.FC<{
   tutors: ITutor.FindOnboardedTutorsApiResponse;
 }> = ({ tutors }) => {
-  const intl = useFormatMessage();
-
   return (
     <div className="bg-natural-0 max-w-screen">
       <InViewTrack event="view_item_list" label="tutors" action="scroll" />
@@ -21,13 +19,13 @@ export const Tutors: React.FC<{
             tag="h3"
             className="text-subtitle-1 md:text-h4 lg:text-h3 font-bold text-natural-950"
           >
-            {highlight(intl, "home/tutors/title")}
+            <Highlight id="home/tutors/title" />
           </Typography>
           <Typography
             tag="h6"
             className="text-body md:text-subtitle-2 font-medium md:font-semibold  text-natural-700"
           >
-            {highlight(intl, "home/tutors/description")}
+            <Highlight id="home/tutors/description" />
           </Typography>
         </div>
 

--- a/apps/landing/hooks/intl.ts
+++ b/apps/landing/hooks/intl.ts
@@ -1,5 +1,4 @@
 import { LocalId } from "@/locales/request";
-import { Typography } from "@litespace/ui/Typography";
 import { RichTranslationValues, useTranslations } from "next-intl";
 
 import React, { useCallback, useMemo } from "react";
@@ -20,17 +19,4 @@ export function useFormatMessage() {
       }),
     [format, intl]
   );
-}
-
-export function highlight(
-  intl: ReturnType<typeof useFormatMessage>,
-  id: LocalId
-) {
-  return intl.rich(id, {
-    highlight: (chunks) => (
-      <Typography tag="span" className="text-brand-500">
-        {chunks}
-      </Typography>
-    ),
-  });
 }


### PR DESCRIPTION
The `highlight` function in hooks/intl file, for some reason worked only locally. It didn't work on the staging server. So it's replaced by a react component `Highlight`.