### PR TITLE
fix: avatar component loading image bug has been fixed.

### DIFF
--- a/packages/ui/src/components/Avatar/AvatarV2.tsx
+++ b/packages/ui/src/components/Avatar/AvatarV2.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Logo from "@litespace/assets/LogoAvatar";
-import React, { useMemo, useCallback, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import cn from "classnames";
 import { optional } from "@litespace/utils";
-
-type Status = "loading" | "loaded" | "error";
+import { imageUrlToBase64 } from "@/lib/avatar";
 
 const COLOR_STYLES = [
   // green
@@ -41,15 +40,12 @@ export const AvatarV2: React.FC<{
   id?: number | null;
   object?: "fill" | "contain" | "cover" | "none" | "scale-down";
 }> = ({ src, alt, id, object = "cover" }) => {
-  const [status, setStatus] = useState<Status>("loading");
+  const [imgData, setImgData] = useState<string | null>(null);
 
-  const onLoad = useCallback(() => {
-    setStatus("loaded");
-  }, []);
-
-  const onError = useCallback(() => {
-    setStatus("error");
-  }, []);
+  useEffect(() => {
+    if (!src) return;
+    imageUrlToBase64(src).then((res) => setImgData(res));
+  }, [src]);
 
   const mod = useMemo(() => {
     return Math.floor((id || 0) % COLOR_STYLES.length);
@@ -58,7 +54,7 @@ export const AvatarV2: React.FC<{
   return (
     <div data-mod={mod} className="relative w-full h-full overflow-hidden">
       <img
-        data-status={status}
+        data-status={imgData ? "loaded" : "loading"}
         className={cn(
           "opacity-0 transition-opacity duration-300 ease-linear",
           "data-[status=loaded]:opacity-100 absolute w-full h-full",
@@ -70,13 +66,11 @@ export const AvatarV2: React.FC<{
             "object-scale-down": object === "scale-down",
           }
         )}
-        src={optional(src)}
+        src={optional(imgData)}
         alt={optional(alt)}
-        onLoad={onLoad}
-        onError={onError}
       />
       <div
-        data-status={status}
+        data-status={imgData ? "loaded" : "loading"}
         className={cn(
           "opacity-100 transition-opacity duration-300",
           "data-[status=loaded]:opacity-0",

--- a/packages/ui/src/lib/avatar.ts
+++ b/packages/ui/src/lib/avatar.ts
@@ -1,0 +1,15 @@
+export async function imageUrlToBase64(url: string): Promise<string> {
+  const blob = await fetch(url).then((res) => res.blob());
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (typeof reader.result !== "string") return reject;
+      if (!reader.result.startsWith("data:image")) return reject;
+      const base64String = reader.result;
+      resolve(base64String);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}


### PR DESCRIPTION
A nondeterministic bug in the avatarV2 component, especially when used in the landing page, has been fixed.

## The Bug

The `onLoad` callback was sometimes not fired from the HTML `img` component. And so the already loaded image is not displayed.

## The Solution

The image is being fetched with the `fetch` function, read in base64 with `FileReader`, and then assigned to the `img` src.