### PR TITLE
fix: stop navigating students to complete-profile each time.

### DIFF
--- a/apps/web/src/hooks/google.ts
+++ b/apps/web/src/hooks/google.ts
@@ -63,7 +63,10 @@ export function useGoogle({
       user.set(info);
 
       if (redirect) return navigate(redirect);
-      if (role) return navigate(Web.CompleteProfile);
+
+      if (role === IUser.Role.Student && !info.user.name)
+        return navigate(Web.CompleteProfile);
+
       return navigate(Web.Root);
     },
     [api.auth, intl, navigate, redirect, role, toast, user]


### PR DESCRIPTION
### Summary

When students sign in with google, litespace asks them to complete-profiles regardless of it's already complete or not. This has been modified by checking first if the student has assigned his name; and skip the complete-profile step if so, assuming that he/she had completed the profile.
