### PR TITLE
fix/improve: refunds web integration has been improved, updading refunding status fixed, and send whatsapp messages forced.

### DIFF
--- a/apps/web/src/components/Settings/RefundsTable.tsx
+++ b/apps/web/src/components/Settings/RefundsTable.tsx
@@ -11,6 +11,7 @@ import { useUser } from "@litespace/headless/context/user";
 import { Button } from "@litespace/ui/Button";
 import { useRender } from "@litespace/headless/common";
 import RefundDialog from "@/components/StudentSettings/RefundDialog";
+import { Loading } from "@litespace/ui/Loading";
 
 const RefundsTable: React.FC = () => {
   const intl = useFormatMessage();
@@ -24,6 +25,8 @@ const RefundsTable: React.FC = () => {
     () => lessons.data?.filter((l) => l.reported) || [],
     [lessons.data]
   );
+
+  if (lessons.isPending) return <Loading />;
 
   if (isEmpty(canceledLessons) && isEmpty(reportedLessons))
     return (

--- a/packages/types/src/lesson.ts
+++ b/packages/types/src/lesson.ts
@@ -77,6 +77,7 @@ export type MetaSelf = Self & {
   txStatus: ITransaction.Status;
   txFees: number;
   txAmount: number;
+  txCreatedAt: string;
   orderRefNum: ITransaction.Self["providerRefNum"];
 };
 

--- a/services/jobs/src/jobs/lesson.ts
+++ b/services/jobs/src/jobs/lesson.ts
@@ -118,7 +118,8 @@ function getReminderMsgForMember({
 
 async function send(messages: IMessenger.Message[]) {
   if (isEmpty(messages)) return;
-  for (const msg of messages) sendMsg({ ...msg, method: msg.method || null });
+  for (const msg of messages)
+    sendMsg({ ...msg, method: msg.method || null }, true);
 }
 
 export default { start };

--- a/services/jobs/src/lib/messager.ts
+++ b/services/jobs/src/lib/messager.ts
@@ -11,8 +11,8 @@ export const messenger = new Messenger({
   profileId: config.whatsAppAPI.profileId,
 });
 
-export function sendMsg(msg: Required<IMessenger.Message>) {
-  if (msg.method === IUser.NotificationMethod.Whatsapp) {
+export function sendMsg(msg: Required<IMessenger.Message>, force?: boolean) {
+  if (force || msg.method === IUser.NotificationMethod.Whatsapp) {
     messenger.whatsapp
       .sendSimpleMessage({
         to: msg.to.startsWith("2") ? msg.to : `2${msg.to}`,

--- a/services/server/src/handlers/fawry.ts
+++ b/services/server/src/handlers/fawry.ts
@@ -742,7 +742,8 @@ async function syncPaymentStatus(
     // terminate subscription in case the tx was canceled, refunded, or failed.
     if (
       subscription &&
-      (status === ITransaction.Status.Canceled ||
+      (transaction.status === ITransaction.Status.Refunding ||
+        status === ITransaction.Status.Canceled ||
         status === ITransaction.Status.Refunded ||
         status === ITransaction.Status.Failed)
     )


### PR DESCRIPTION
### Summary

- Whatsapp messages were not forced in the _jobs_ service.
- Fawry doesn't inform us when  a refund status is changed. So, getPaymentStatus used whenever the user checkout his refunds.
- The UI no longer shows all refund requests even the ones that have been used.  
