### PR TITLE
fix: minor bug in manage-lesson-dialog.

### DIFF
--- a/packages/ui/src/components/Lessons/ManageLesson/ManageLessonDialog.tsx
+++ b/packages/ui/src/components/Lessons/ManageLesson/ManageLessonDialog.tsx
@@ -220,7 +220,7 @@ export const ManageLessonDialog: React.FC<{
     () =>
       subtractSlots({ slots, subslots: bookedSlots }).filter(
         (slot) =>
-          dayjs(slot.start).isAfter(dayjs()) &&
+          dayjs(slot.start).isAfter(dayjs().startOf("day")) &&
           dayjs(slot.start).isBefore(dateBounds?.end)
       ),
     [slots, bookedSlots, dateBounds?.end]


### PR DESCRIPTION
### Summary

The current day was sometimes disabled because of a minor bug in a boolean expression.