### PR TITLE
add student (name or email) in chat page

### DIFF
--- a/apps/web/src/components/Chat/Messages.tsx
+++ b/apps/web/src/components/Chat/Messages.tsx
@@ -41,6 +41,7 @@ import { useInvalidateQuery } from "@litespace/headless/query";
 import { QueryKey } from "@litespace/headless/constants";
 import { capture } from "@/lib/sentry";
 import { useOnError } from "@/hooks/error";
+import { getEmailUserName } from "@litespace/utils";
 
 type RetryFnMap = Record<
   "send" | "update" | "delete",
@@ -92,6 +93,11 @@ const Messages: React.FC<{
   onNewMessage,
 }) => {
   const { user } = useUser();
+
+  const displayName =
+    otherMember?.name ||
+    (otherMember?.email ? getEmailUserName(otherMember.email) : null);
+
   const intl = useFormatMessage();
   const messagesRef = useRef<HTMLUListElement>(null);
 
@@ -297,8 +303,6 @@ const Messages: React.FC<{
     el.scrollTop += 100;
   }, [messageGroups]);
 
-  console.log(otherMember);
-
   return (
     <div
       id="messages-container"
@@ -311,7 +315,7 @@ const Messages: React.FC<{
       {otherMember ? (
         <ChatHeader
           id={otherMember.id}
-          name={otherMember.name}
+          name={displayName}
           image={otherMember.image}
           role={otherMember.role}
           online={isOnline}

--- a/apps/web/src/components/Chat/Rooms.tsx
+++ b/apps/web/src/components/Chat/Rooms.tsx
@@ -19,6 +19,7 @@ import People from "@litespace/assets/People";
 import { optional } from "@litespace/utils/utils";
 import dayjs from "@/lib/dayjs";
 import { InView } from "react-intersection-observer";
+import { getEmailUserName } from "@litespace/utils";
 
 type RoomsData = {
   icon: React.ReactNode;
@@ -144,7 +145,12 @@ const Rooms: React.FC<{
                   : data.id // tutor id
               }
               imageUrl={optional(room ? data.otherMember.image : data.image)}
-              name={optional(room ? data.otherMember.name : data.name)}
+              name={optional(
+                room
+                  ? data.otherMember.name ||
+                      getEmailUserName(data.otherMember.email as string)
+                  : data.name || getEmailUserName(data.email as string)
+              )}
               message={asRoomMessage({
                 message: room ? data.latestMessage : null,
                 bio: !room ? data.bio : null,

--- a/apps/web/src/lib/room.ts
+++ b/apps/web/src/lib/room.ts
@@ -5,6 +5,7 @@ import { IRoom, IUser } from "@litespace/types";
 type OtherMember = {
   id: number;
   name: string | null;
+  email: string | null;
   image: string | null;
   role: IUser.Role;
   lastSeen: string;
@@ -25,6 +26,7 @@ export function asOtherMember({
   return {
     id: otherMember.id,
     name: otherMember.name || null,
+    email: otherMember.email || null,
     gender: otherMember.gender || null,
     image: otherMember.image || null,
     role: otherMember.role,

--- a/packages/models/src/tutors.ts
+++ b/packages/models/src/tutors.ts
@@ -431,6 +431,7 @@ export class Tutors {
       image: users.column("image"),
       bio: this.column("bio"),
       name: users.column("name"),
+      email: users.column("email"),
       gender: users.column("gender"),
       role: users.column("role"),
       lastSeen: users.column("updated_at"),

--- a/packages/types/src/room.ts
+++ b/packages/types/src/room.ts
@@ -75,6 +75,7 @@ export type FindUserRoomsApiRecord = {
   otherMember: {
     id: number;
     name: string | null;
+    email?: string | null;
     image: string | null;
     role: IUser.Role;
     lastSeen: string;

--- a/packages/types/src/tutor.ts
+++ b/packages/types/src/tutor.ts
@@ -114,6 +114,7 @@ export type Assets = {
 export type UncontactedTutorInfo = {
   id: number;
   name: string | null;
+  email?: string | null;
   image: string | null;
   bio: string | null;
   role: IUser.Role;

--- a/services/server/src/lib/chat.ts
+++ b/services/server/src/lib/chat.ts
@@ -26,6 +26,7 @@ export function asFindUserRoomsApiRecord({
     otherMember: {
       id: otherMember.id,
       name: otherMember.name,
+      email: otherMember.email,
       image: otherMember.image,
       role: otherMember.role,
       lastSeen: otherMember.lastSeen,


### PR DESCRIPTION
### Summary

show student's email on chat page if they don't have a name